### PR TITLE
Fix bug: use our instead of my.

### DIFF
--- a/lib/Test/Inline.pm6
+++ b/lib/Test/Inline.pm6
@@ -1,6 +1,6 @@
 unit module Inline;
 
-my Sub @tests;
+our @tests;
 
 #| Marks a sub as being for internal test purposes
 multi sub trait_mod:<is>(Sub $sub, :$test!) is export {


### PR DESCRIPTION
Test::Inline does not seem to work on the latest version of Raku. No inline tests are run, as @tests seems to be empty. This seems to fix it.